### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,14 @@ install:
 	mkdir -p $(PG_SHAREDIR)/emaj
 	mkdir -p $(PG_DOCDIR)/emaj
 	cp sql/* $(PG_SHAREDIR)/emaj/.
-	sed -r "s|^#directory\s+=.*$$|directory = 'emaj'|" emaj.control >$(PG_SHAREDIR)/extension/emaj.control
-	-cp doc/* $(PG_DOCDIR)/emaj/.
-	cp client/* $(PG_BINDIR)/.
+	sed -r "s|^#directory[[:space:]]+=.+|directory = 'emaj'|" emaj.control >$(PG_SHAREDIR)/extension/emaj.control
+	cp -rf docs/* $(PG_DOCDIR)/emaj/
+	cp client/* $(PG_BINDIR)/
 
 uninstall:
 	rm -f $(PG_BINDIR)/emaj*
 	rm -rf $(PG_DOCDIR)/emaj
 	rm -rf $(PG_SHAREDIR)/emaj
 	rm -f $(PG_SHAREDIR)/extension/emaj.control
+
+installcheck:


### PR DESCRIPTION
*   Get the `sed` command working on Darwin
*   Install `docs`, not `doc`
*   Add an `installcheck` target, currently a no-op.

I tried running `/tools/regress.sh` but it seemed to want more configuration. Not sure how to properly support an `inastallcheck` target, but this will at least prevent it from failing when automation tooling tries to run it.