### PR TITLE
Use PGXS for installation and un-installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,38 +1,21 @@
 # File: Makefile
 # E-Maj extension
 
-# This Makefile doesn't use PGXS because PGXS fails to remove all doc and bin
-#   files at uninstall time when these files come from subdirectories.
-# But it places the components at the same place, as if we had:
-# EXTENSION    = emaj
-# MODULEDIR    = emaj
-# DATA         = $(wildcard sql/*)
-# DOCS         = $(wildcard doc/*)
-# SCRIPTS      = $(wildcard client/*)
-# PG_CONFIG   ?= pg_config
-# PGXS := $(shell $(PG_CONFIG) --pgxs)
-# include $(PGXS)
-
+EXTENSION    = emaj
+MODULEDIR    = emaj
+DATA         = $(wildcard sql/*)
+SCRIPTS      = $(wildcard client/*)
+ifneq ($(wildcard doc/*),) 
+DOCS         = $(wildcard doc/*)
+endif
 PG_CONFIG   ?= pg_config
-PG_SHAREDIR := $(shell $(PG_CONFIG) --sharedir)
-PG_BINDIR   := $(shell $(PG_CONFIG) --bindir)
-PG_DOCDIR   := $(shell $(PG_CONFIG) --docdir)
 
-all:
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
 
-install:
-	mkdir -p $(PG_SHAREDIR)/extension
-	mkdir -p $(PG_SHAREDIR)/emaj
-	mkdir -p $(PG_DOCDIR)/emaj
-	cp sql/* $(PG_SHAREDIR)/emaj/.
-	sed -r "s|^#directory[[:space:]]+=.+|directory = 'emaj'|" emaj.control >$(PG_SHAREDIR)/extension/emaj.control
-	-cp doc/* $(PG_DOCDIR)/emaj/
-	cp client/* $(PG_BINDIR)/
+# Additional target to remove bin and docs files, which PGXS does not do.
+uninstall: uninstall_more
 
-uninstall:
-	rm -f $(PG_BINDIR)/emaj*
-	rm -rf $(PG_DOCDIR)/emaj
-	rm -rf $(PG_SHAREDIR)/emaj
-	rm -f $(PG_SHAREDIR)/extension/emaj.control
-
-installcheck:
+uninstall_more:
+	rm -f $(DESTDIR)$(shell $(PG_CONFIG) --bindir)/emaj*
+	rm -rf $(DESTDIR)$(shell $(PG_CONFIG) --docdir)/emaj

--- a/emaj.control
+++ b/emaj.control
@@ -3,7 +3,7 @@
 
 default_version = 'devel'
 comment         = 'E-Maj extension enables fine-grained write logging and time travel on subsets of the database.'
-#directory 	    = '<directory containing installation scripts, if not SHAREDIR>'
+#directory 	    = 'emaj'
 superuser       = true
 schema 	        = 'emaj'
 relocatable     = false


### PR DESCRIPTION
Notably, this allows it to work whether or not there is a `doc` directory and allows the `DESTDIR` variable to work, which is often used when building packages.

Work around an empty `doc` directory by only setting `DOCS` if there are docs. Add the `uninstall_more` target and add it to the dependencies for PGXS's `install` target to clean up bin and doc files.

Follow-up to #56.